### PR TITLE
added db_port in connectDatabase function for docker support

### DIFF
--- a/pp-content/pp-include/pp-functions.php
+++ b/pp-content/pp-include/pp-functions.php
@@ -80,11 +80,12 @@
     }
 
     function connectDatabase() {
-        global $db_host, $db_user, $db_pass, $db_name;
+        global $db_host, $db_port, $db_user, $db_pass, $db_name;
+        $db_port = $db_port ?? 3306; // fallback
 
-        try {
+    try {
             // Build DSN
-            $dsn = "mysql:host=$db_host;dbname=$db_name;charset=utf8mb4";
+            $dsn = "mysql:host=$db_host;port=$db_port;dbname=$db_name;charset=utf8mb4";
 
             // Create PDO instance
             $pdo = new PDO($dsn, $db_user, $db_pass, [

--- a/pp-content/pp-install/index.php
+++ b/pp-content/pp-install/index.php
@@ -66,7 +66,8 @@
 
             // Write config file
             $configContent = "<?php
-    \$db_host = '".addslashes($host)."';
+    \$db_host = '".addslashes($host). "';
+    \$db_port = '" . addslashes($port) . "'; 
     \$db_user = '".addslashes($username)."';
     \$db_pass = '".addslashes($password)."';
     \$db_name = '".addslashes($dbname)."';


### PR DESCRIPTION
I have made some tiny changes in configContent and connectDatabase. I found this problem when I tried to use PipraPay in Docker and also when I tried to use it on a different MariaDB server that uses a different port. In this case, I saw that PipraPay was able to successfully create the tables the first time, but it was not able to create the admin user info. Then I found the problem was the DB port. I changed this tiny piece of code and it worked. I think it will be valuable for other advanced users.