### PR TITLE
fix: resolve 404 error by correcting tabler-socials css path [pp-content/pp-admin/index.php]

### DIFF
--- a/pp-content/pp-admin/index.php
+++ b/pp-content/pp-admin/index.php
@@ -34,7 +34,7 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-flags.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-payments.min.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-social.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-socials.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler-vendors.min.css" />
 
     <style>


### PR DESCRIPTION
This PR fixes a broken CDN link in the document head. The previous reference to `tabler-social.min.css` was incorrect and resulted in a 404 (Not Found) error. 

I have updated the filename to the correct plural form `tabler-socials.min.css` as per the official @tabler/core 1.4.0 distribution.

## Linked Issues
Fixes #404 (Replace with actual issue ID if applicable)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
