### PR TITLE
Fix/payment verification bug surjopay

### DIFF
--- a/index.php
+++ b/index.php
@@ -892,11 +892,80 @@
 
                                         $response_transaction = json_decode(getData($db_prefix.'transaction','WHERE ref = :ref', '* FROM', $params),true);
                                         if($response_transaction['status'] == true){
+                                            if (($response_transaction['response'][0]['status'] ?? '') !== 'completed') {
+                                                http_response_code(400);
+                                                echo json_encode([
+                                                    'error' => [
+                                                        'code' => 'INVALID_STATUS',
+                                                        'message' => 'Only completed transactions can be refunded.'
+                                                    ]
+                                                ]);
+                                                exit;
+                                            }
+
+                                            $transactionRow = $response_transaction['response'][0];
+                                            $refundResult = null;
+
+                                            $params = [ ':gateway_id' => $transactionRow['gateway_id'], ':brand_id' => $transactionRow['brand_id'] ];
+                                            $response_gateway_info = json_decode(getData($db_prefix.'gateways','WHERE gateway_id = :gateway_id AND brand_id = :brand_id', '* FROM', $params),true);
+                                            $gateway_slug = $response_gateway_info['response'][0]['slug'] ?? '';
+
+                                            if ($gateway_slug === 'bkash-api-tokenized') {
+                                                $refundPayload = [
+                                                    'amount' => money_round($transactionRow['local_net_amount']),
+                                                    'sku' => $transactionRow['ref'],
+                                                    'reason' => 'API refund'
+                                                ];
+
+                                                $refundResult = pp_bkash_tokenized_refund($transactionRow, $refundPayload);
+
+                                                if (empty($refundResult['status'])) {
+                                                    http_response_code(400);
+                                                    echo json_encode([
+                                                        'error' => [
+                                                            'code' => 'REFUND_FAILED',
+                                                            'message' => $refundResult['message'] ?? 'Refund failed.'
+                                                        ]
+                                                    ]);
+                                                    exit;
+                                                }
+                                            }
+
+                                            $source_info = json_decode($transactionRow['source_info'], true) ?: [];
+                                            $source_info_changed = false;
+
+                                            if (!empty($refundResult['data'])) {
+                                                $refundTrxId = $refundResult['data']['refundTrxId'] ?? '';
+                                                $refundAmount = $refundResult['data']['refundAmount'] ?? '';
+                                                $completedTime = $refundResult['data']['completedTime'] ?? '';
+
+                                                if ($refundTrxId !== '') {
+                                                    $source_info[] = ['label' => 'Refund TrxID', 'value' => $refundTrxId];
+                                                    $source_info_changed = true;
+                                                }
+                                                if ($refundAmount !== '') {
+                                                    $source_info[] = ['label' => 'Refund Amount', 'value' => $refundAmount];
+                                                    $source_info_changed = true;
+                                                }
+                                                if ($completedTime !== '') {
+                                                    $source_info[] = ['label' => 'Refund Time', 'value' => $completedTime];
+                                                    $source_info_changed = true;
+                                                }
+                                            }
+
                                             $columns = ['status',  'updated_date'];
                                             $values = ['refunded', getCurrentDatetime('Y-m-d H:i:s')];
                                             $condition = 'id ="'.$response_transaction['response'][0]['id'].'"'; 
 
+                                            if ($source_info_changed) {
+                                                $columns[] = 'source_info';
+                                                $values[] = json_encode($source_info, JSON_UNESCAPED_UNICODE);
+                                                $response_transaction['response'][0]['source_info'] = json_encode($source_info, JSON_UNESCAPED_UNICODE);
+                                            }
+
                                             updateData($db_prefix.'transaction', $columns, $values, $condition);
+
+                                            $response_transaction['response'][0]['status'] = 'refunded';
 
 
                                             $metadata = json_decode($response_transaction['response'][0]['metadata'], true) ?: [];

--- a/pp-content/pp-include/pp-adapter.php
+++ b/pp-content/pp-include/pp-adapter.php
@@ -6837,6 +6837,7 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
                             $all_transactions = [];
 
                             $jobs = [];
+                            $failed = [];
 
                             foreach ($selected_ids as $id) {
                                 $itemID = escape_string($id);
@@ -6864,12 +6865,74 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
 
                                     if($actionID == "refunded"){
                                         if (hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'transaction', 'refund', $global_user_response['response'][0]['role'])) {
+                                            $transactionRow = $response_brand['response'][0];
+
+                                            if (($transactionRow['status'] ?? '') !== 'completed') {
+                                                $failed[] = [
+                                                    'ref' => $itemID,
+                                                    'message' => 'Only completed transactions can be refunded.'
+                                                ];
+                                                continue;
+                                            }
+
+                                            $refundResult = null;
+                                            $params = [ ':gateway_id' => $transactionRow['gateway_id'], ':brand_id' => $transactionRow['brand_id'] ];
+                                            $response_gateway_info = json_decode(getData($db_prefix.'gateways','WHERE gateway_id = :gateway_id AND brand_id = :brand_id', '* FROM', $params),true);
+                                            $gateway_slug = $response_gateway_info['response'][0]['slug'] ?? '';
+
+                                            if ($gateway_slug === 'bkash-api-tokenized') {
+                                                $refundPayload = [
+                                                    'amount' => money_round($transactionRow['local_net_amount']),
+                                                    'sku' => $transactionRow['ref'],
+                                                    'reason' => 'Admin refund'
+                                                ];
+
+                                                $refundResult = pp_bkash_tokenized_refund($transactionRow, $refundPayload);
+
+                                                if (empty($refundResult['status'])) {
+                                                    $failed[] = [
+                                                        'ref' => $itemID,
+                                                        'message' => $refundResult['message'] ?? 'Refund failed.'
+                                                    ];
+                                                    continue;
+                                                }
+                                            }
+
+                                            $source_info = json_decode($transactionRow['source_info'], true) ?: [];
+                                            $source_info_changed = false;
+
+                                            if (!empty($refundResult['data'])) {
+                                                $refundTrxId = $refundResult['data']['refundTrxId'] ?? '';
+                                                $refundAmount = $refundResult['data']['refundAmount'] ?? '';
+                                                $completedTime = $refundResult['data']['completedTime'] ?? '';
+
+                                                if ($refundTrxId !== '') {
+                                                    $source_info[] = ['label' => 'Refund TrxID', 'value' => $refundTrxId];
+                                                    $source_info_changed = true;
+                                                }
+                                                if ($refundAmount !== '') {
+                                                    $source_info[] = ['label' => 'Refund Amount', 'value' => $refundAmount];
+                                                    $source_info_changed = true;
+                                                }
+                                                if ($completedTime !== '') {
+                                                    $source_info[] = ['label' => 'Refund Time', 'value' => $completedTime];
+                                                    $source_info_changed = true;
+                                                }
+                                            }
+
                                             $columns = ['status', 'updated_date'];
                                             $values = ['refunded', getCurrentDatetime('Y-m-d H:i:s')];
 
+                                            if ($source_info_changed) {
+                                                $columns[] = 'source_info';
+                                                $values[] = json_encode($source_info, JSON_UNESCAPED_UNICODE);
+                                                $response_brand['response'][0]['source_info'] = json_encode($source_info, JSON_UNESCAPED_UNICODE);
+                                            }
+
                                             $condition = "ref = '".$itemID."'"; 
-                                            
                                             updateData($db_prefix.'transaction', $columns, $values, $condition);
+
+                                            $response_brand['response'][0]['status'] = 'refunded';
                                         }
                                     }
 
@@ -6986,7 +7049,22 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
                                 do_action('transactions.updated', $all_transactions);
                             }
 
-                            echo json_encode(['status' => 'true', 'title' => 'Transactions '.$actionsID, 'message' => 'The selected transactions have been '.$actionsID.' successfully.', 'csrf_token' => $new_csrf_token]);
+                            if (!empty($failed)) {
+                                $firstFail = $failed[0];
+                                $failCount = count($failed);
+                                $message = $failCount > 1
+                                    ? $firstFail['message'].' (and '.($failCount - 1).' more)'
+                                    : $firstFail['message'];
+
+                                echo json_encode([
+                                    'status' => 'false',
+                                    'title' => 'Refund Failed',
+                                    'message' => $message,
+                                    'csrf_token' => $new_csrf_token
+                                ]);
+                            }else{
+                                echo json_encode(['status' => 'true', 'title' => 'Transactions '.$actionsID, 'message' => 'The selected transactions have been '.$actionsID.' successfully.', 'csrf_token' => $new_csrf_token]);
+                            }
                         } else {
                             echo json_encode(['status' => 'false', 'title' => 'Transactions Failed', 'message' => 'No transactions selected.' , 'csrf_token' => $new_csrf_token]);
                         }
@@ -9591,4 +9669,3 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
         exit;
 
     }
-

--- a/pp-content/pp-include/pp-functions.php
+++ b/pp-content/pp-include/pp-functions.php
@@ -493,6 +493,96 @@
         return bcdiv($tmp, bcpow('10', (string)$decimals), $decimals);
     }
 
+    function pp_get_gateway_options($gateway_id = '', $brand_id = ''){
+        global $db_prefix;
+
+        $options = [];
+
+        if ($gateway_id === '' || $brand_id === '') {
+            return $options;
+        }
+
+        $params = [ ':gateway_id' => $gateway_id, ':brand_id' => $brand_id ];
+        $response_gateways_parameter = json_decode(getData($db_prefix.'gateways_parameter','WHERE gateway_id = :gateway_id AND brand_id = :brand_id', '* FROM', $params),true);
+
+        if ($response_gateways_parameter['status'] == true) {
+            foreach($response_gateways_parameter['response'] as $field){
+                $value = $field['value'];
+
+                if(!empty($field['multiple']) && !empty($value)){
+                    $value = is_array($value) ? $value : json_decode($value, true);
+                }
+
+                $options[$field['option_name']] = $value;
+            }
+        }
+
+        return $options;
+    }
+
+    function pp_bkash_tokenized_refund($transaction = [], $refund = []){
+        $gateway_id = $transaction['gateway_id'] ?? '';
+        $brand_id = $transaction['brand_id'] ?? '';
+
+        if ($gateway_id === '' || $brand_id === '') {
+            return [
+                'status' => false,
+                'message' => 'Gateway or brand not found.',
+            ];
+        }
+
+        $options = $refund['options'] ?? pp_get_gateway_options($gateway_id, $brand_id);
+
+        if (empty($options)) {
+            return [
+                'status' => false,
+                'message' => 'bKash configuration is missing.',
+            ];
+        }
+
+        if (isset($options['auto_refund']) && $options['auto_refund'] === 'off') {
+            return [
+                'status' => false,
+                'message' => 'Auto refund is disabled for this gateway.',
+            ];
+        }
+
+        $gateway_path = __DIR__ . '/../pp-modules/pp-gateways/bkash-api-tokenized/class.php';
+        if (!file_exists($gateway_path)) {
+            return [
+                'status' => false,
+                'message' => 'bKash gateway not installed.',
+            ];
+        }
+
+        require_once $gateway_path;
+
+        if (!class_exists('BkashApiTokenizedGateway')) {
+            return [
+                'status' => false,
+                'message' => 'bKash gateway class not found.',
+            ];
+        }
+
+        $gateway = new BkashApiTokenizedGateway();
+
+        if (!method_exists($gateway, 'refund')) {
+            return [
+                'status' => false,
+                'message' => 'Refund not supported by this gateway.',
+            ];
+        }
+
+        $payload = [
+            'transaction' => $transaction,
+            'options' => $options,
+            'refund' => $refund,
+        ];
+
+        return $gateway->refund($payload);
+    }
+
+
     function verifyPaymentTolerance(string $checkout, string $paid, string $tolerance): bool{
         $checkout  = money_round($checkout);
         $paid      = money_round($paid);
@@ -3452,4 +3542,3 @@
             $this->offset = null;
         }
     }
-

--- a/pp-content/pp-modules/pp-gateways/bkash-api-tokenized/class.php
+++ b/pp-content/pp-modules/pp-gateways/bkash-api-tokenized/class.php
@@ -58,6 +58,18 @@
                     'required' => true,
                     'multiple' => false,
                 ],
+                [
+                    'name'  => 'auto_refund',
+                    'label' => 'Auto Refund API',
+                    'type'  => 'select',
+                    'options' => [
+                        'on'  => 'On',
+                        'off' => 'Off',
+                    ],
+                    'value' => 'on',
+                    'required' => false,
+                    'multiple' => false,
+                ],
             ];
         }
 
@@ -198,5 +210,325 @@
                     echo '<div class="alert alert-danger" role="alert">Transaction not valid or not found.</div><style>.loading-123412341234{display: none;}</style>';
                 }
             }
+        }
+
+        public function refund($data = []){
+            $transaction = $data['transaction'] ?? [];
+            $options = $data['options'] ?? [];
+            $refund = $data['refund'] ?? [];
+
+            $paymentId = $refund['paymentId'] ?? '';
+            if ($paymentId === '') {
+                $paymentId = $this->extractPaymentId($transaction['source_info'] ?? '');
+            }
+
+            $trxId = $transaction['trx_id'] ?? '';
+            $refundAmount = $refund['amount'] ?? ($transaction['local_net_amount'] ?? '');
+            $refundAmount = money_round($refundAmount);
+
+            $sku = $refund['sku'] ?? ($transaction['ref'] ?? 'refund');
+            $reason = $refund['reason'] ?? 'Admin refund';
+
+            if ($paymentId === '') {
+                return [
+                    'status' => false,
+                    'message' => 'Payment ID not found for this transaction.',
+                ];
+            }
+
+            if ($trxId === '' || $refundAmount === '' || $refundAmount === '0') {
+                return [
+                    'status' => false,
+                    'message' => 'Missing required refund fields.',
+                ];
+            }
+
+            $base_url = (($options['mode'] ?? 'sandbox') === 'live') ? 'https://tokenized.pay.bka.sh/v1.2.0-beta/tokenized' : 'https://tokenized.sandbox.bka.sh/v1.2.0-beta/tokenized';
+
+            $tokenData = $this->grantToken($base_url, $options);
+            $token = $tokenData['token'] ?? '';
+            if ($token === '') {
+                return [
+                    'status' => false,
+                    'message' => 'Failed to obtain bKash token.',
+                ];
+            }
+
+            $headers = [
+                'Authorization:' . $token,
+                'X-APP-Key:' . ($options['app_key'] ?? ''),
+            ];
+
+            $refundPayload = [
+                'paymentId' => $paymentId,
+                'trxId' => $trxId,
+                'refundAmount' => $refundAmount,
+                'sku' => $sku,
+                'reason' => $reason,
+            ];
+
+            $refundRes = $this->postJsonWithFallback('/v2/tokenized-checkout/refund/payment/transaction', $refundPayload, $headers, $base_url);
+            $refundBaseUrl = $refundRes['used_base'] ?? $base_url;
+            $refundData = $refundRes['data'] ?? [];
+            if (empty($refundData) && !empty($refundRes['raw'])) {
+                $refundData = ['raw' => $refundRes['raw']];
+            }
+
+            if (!empty($refundData['refundTransactionStatus']) && strtolower($refundData['refundTransactionStatus']) === 'completed') {
+                return [
+                    'status' => true,
+                    'message' => 'Refund completed.',
+                    'data' => $refundData,
+                ];
+            }
+
+            if ($refundRes['ok'] !== true) {
+                $err = $refundRes['error'] ?? '';
+                $code = $refundRes['http_code'] ?? 0;
+                $msg = $err !== '' ? $err : 'Refund request failed.';
+                if ($code) {
+                    $msg .= ' (HTTP '.$code.')';
+                }
+
+                return [
+                    'status' => false,
+                    'message' => $msg,
+                    'data' => $refundData,
+                ];
+            }
+
+            $statusPayload = [
+                'paymentId' => $paymentId,
+                'trxId' => $trxId,
+            ];
+
+            $statusRes = $this->postJsonWithFallback('/v2/tokenized-checkout/refund/payment/status', $statusPayload, $headers, $refundBaseUrl);
+            $statusData = $statusRes['data'] ?? [];
+            if (empty($statusData) && !empty($statusRes['raw'])) {
+                $statusData = ['raw' => $statusRes['raw']];
+            }
+
+            $matched = $this->findCompletedRefund($statusData, $refundAmount);
+            if (!empty($matched)) {
+                return [
+                    'status' => true,
+                    'message' => 'Refund completed.',
+                    'data' => $matched,
+                    'status_data' => $statusData,
+                ];
+            }
+
+            $errorMessage = $refundData['errorMessageEn'] ?? ($statusData['errorMessageEn'] ?? '');
+            $externalCode = $refundData['externalCode'] ?? ($statusData['externalCode'] ?? '');
+            $statusMessage = $refundData['statusMessage'] ?? ($statusData['statusMessage'] ?? '');
+
+            if ($errorMessage === '') {
+                $raw = $refundData['raw'] ?? ($statusData['raw'] ?? '');
+                if ($raw !== '') {
+                    $errorMessage = substr($raw, 0, 300);
+                }
+            }
+
+            if ($errorMessage === '' && $statusMessage !== '') {
+                $errorMessage = $statusMessage;
+            }
+
+            if ($errorMessage === '') {
+                $errorMessage = 'Refund failed.';
+            }
+
+            if ($externalCode !== '') {
+                $errorMessage = $errorMessage.' (Code '.$externalCode.')';
+            }
+
+            return [
+                'status' => false,
+                'message' => $errorMessage,
+                'data' => $refundData,
+                'status_data' => $statusData,
+            ];
+        }
+
+        private function grantToken($base_url, $options = []){
+            $request_data = array(
+                'app_key'=> ($options['app_key'] ?? ''),
+                'app_secret'=> ($options['app_secret_key'] ?? '')
+            );
+
+            $headers = array(
+                'username:'.($options['username'] ?? ''),
+                'password:'.($options['password'] ?? '')
+            );
+
+            $response = $this->postJson($base_url.'/checkout/token/grant', $request_data, $headers, 30);
+
+            $token = $response['data']['id_token'] ?? '';
+            if ($token !== '') {
+                $_SESSION['bk-token'] = $token;
+            }
+
+            return [
+                'token' => $token,
+                'response' => $response,
+            ];
+        }
+
+        private function postJson($url, $payload, $headers = [], $timeout = 30){
+            $ch = curl_init($url);
+            $body = json_encode($payload);
+
+            $defaultHeaders = array(
+                'Content-Type:application/json',
+                'Accept: application/json'
+            );
+
+            $mergedHeaders = array_merge($defaultHeaders, $headers);
+
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $mergedHeaders);
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+            curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+            curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+
+            $raw = curl_exec($ch);
+            $error = curl_error($ch);
+            $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
+
+            $data = json_decode($raw, true);
+
+            return [
+                'ok' => ($error === '' && $raw !== false),
+                'http_code' => $code,
+                'raw' => $raw,
+                'data' => $data,
+                'error' => $error,
+                'url' => $url,
+            ];
+        }
+
+        private function extractPaymentId($sourceInfo){
+            if (is_string($sourceInfo)) {
+                $sourceInfo = json_decode($sourceInfo, true);
+            }
+
+            if (!is_array($sourceInfo)) {
+                return '';
+            }
+
+            foreach ($sourceInfo as $item) {
+                $label = $item['label'] ?? '';
+                $value = $item['value'] ?? '';
+
+                if ($label === '' || $value === '') {
+                    continue;
+                }
+
+                $labelLower = strtolower($label);
+                if (strpos($labelLower, 'payment') !== false && strpos($labelLower, 'id') !== false) {
+                    return $value;
+                }
+
+                if ($labelLower === 'paymentid' || $labelLower === 'payment id') {
+                    return $value;
+                }
+            }
+
+            return '';
+        }
+
+        private function findCompletedRefund($statusData, $amount){
+            $refundTransactions = $statusData['refundTransactions'] ?? [];
+            if (!is_array($refundTransactions)) {
+                return [];
+            }
+
+            $targetAmount = money_round($amount);
+
+            foreach ($refundTransactions as $item) {
+                $status = strtolower($item['refundTransactionStatus'] ?? '');
+                $refundAmount = money_round($item['refundAmount'] ?? '0');
+
+                if ($status === 'completed' && ($targetAmount === '0' || $refundAmount === $targetAmount)) {
+                    return $item;
+                }
+            }
+
+            return [];
+        }
+
+        private function postJsonWithFallback($path, $payload, $headers, $baseUrl){
+            $candidates = $this->getRefundBaseCandidates($baseUrl);
+            $lastResponse = null;
+            $usedBase = $baseUrl;
+
+            foreach ($candidates as $candidate) {
+                $usedBase = $candidate;
+                $resp = $this->postJson($candidate.$path, $payload, $headers, 30);
+                $lastResponse = $resp;
+
+                if (!$this->isAwsAuthError($resp)) {
+                    $resp['used_base'] = $candidate;
+                    return $resp;
+                }
+
+            }
+
+            if (is_array($lastResponse)) {
+                $lastResponse['used_base'] = $usedBase;
+                return $lastResponse;
+            }
+
+            return [
+                'ok' => false,
+                'http_code' => 0,
+                'raw' => '',
+                'data' => [],
+                'error' => 'No response',
+                'url' => $usedBase.$path,
+                'used_base' => $usedBase,
+            ];
+        }
+
+        private function getRefundBaseCandidates($baseUrl){
+            $base = rtrim($baseUrl, '/');
+            $candidates = [];
+
+            $candidates[] = $base;
+
+            if (substr($base, -10) === '/tokenized') {
+                $candidates[] = substr($base, 0, -10);
+            }
+
+            $parts = parse_url($base);
+            if (!empty($parts['scheme']) && !empty($parts['host'])) {
+                $root = $parts['scheme'].'://'.$parts['host'];
+                $candidates[] = $root;
+                $candidates[] = $root.'/v1.2.0-beta';
+                $candidates[] = $root.'/v1.2.0-beta/tokenized';
+            }
+
+            $unique = [];
+            foreach ($candidates as $c) {
+                if ($c !== '' && !in_array($c, $unique, true)) {
+                    $unique[] = $c;
+                }
+            }
+
+            return $unique;
+        }
+
+        private function isAwsAuthError($response){
+            $message = '';
+            if (is_array($response)) {
+                $message = $response['data']['message'] ?? ($response['raw'] ?? '');
+            }
+            if (!is_string($message)) {
+                return false;
+            }
+            return (strpos($message, 'Authorization header requires') !== false
+                && strpos($message, 'Credential') !== false);
         }
     }

--- a/pp-content/pp-modules/pp-gateways/shurjopay/class.php
+++ b/pp-content/pp-modules/pp-gateways/shurjopay/class.php
@@ -181,10 +181,14 @@
                 
                 $data_gateway = json_decode($response, true);
 
-                if (isset($data_gateway[0]['bank_status']) && $data_gateway[0]['bank_status'] == "Success") {
-                    $order_id = $data_gateway[0]['customer_order_id'];
+                $sp_code = $data_gateway[0]['sp_code'] ?? '';
+                $bank_status = $data_gateway[0]['bank_status'] ?? '';
 
-                    $after_bp = explode('BP-', $order_id)[1];
+                if ($sp_code == "1000" || $bank_status == "Success") {
+                    $customer_order_id = $data_gateway[0]['customer_order_id'];
+
+                    $parts = explode('BP-', $customer_order_id);
+                    $after_bp = $parts[1] ?? '';
 
                     $moreinfo = [
                         [
@@ -204,8 +208,16 @@
                     pp_set_transaction_status($after_bp, 'completed', $data['gateway']['gateway_id'], $data_gateway[0]['bank_trx_id'], $moreinfo);
 
                     echo "<script>location.href='".pp_checkout_address($after_bp)."';</script>";
-                }else{
-                    echo 'Direct access detected!';
+                } else {
+                    $customer_order_id = $data_gateway[0]['customer_order_id'] ?? '';
+                    $parts = explode('BP-', $customer_order_id);
+                    $after_bp = $parts[1] ?? '';
+
+                    if (!empty($after_bp)) {
+                        pp_set_transaction_status($after_bp, 'canceled', $data['gateway']['gateway_id'], '', []);
+                    }
+
+                    echo "<script>location.href='".pp_checkout_address()."';</script>";
                 }
             }
         }


### PR DESCRIPTION
A failed or unverified payment was being treated like direct URL access.

So two different situations were getting the same response:

Real direct access
User opens the verification/IPN URL manually without order_id
→ showing Direct access detected! is correct.

Payment verification did not return exact success
For example:

customer cancelled payment
gateway/API timing issue
token problem
bank_status returned something other than exactly "Success"
even some valid successful payments where sp_code was 1000 but bank_status differed

→ instead of handling this properly, the code also showed Direct access detected!
That part was the actual bug.