### PR TITLE
Fix infinite redirect loop on /login under nginx (no .htaccess rewrite)

### DIFF
--- a/index.php
+++ b/index.php
@@ -84,6 +84,25 @@
     |--------------------------------------------------------------------------
     */
     $page = $_GET['page'] ?? '';
+
+    /*
+    |--------------------------------------------------------------------------
+    | Fallback router (nginx / PHP built-in server / no .htaccess)
+    |--------------------------------------------------------------------------
+    | The .htaccess RewriteRule that maps "/login" to "index.php?page=login"
+    | only runs under Apache mod_rewrite. On servers that front-control to
+    | index.php without rewriting (e.g. Laravel Valet's nginx), $_GET['page']
+    | is empty, so derive it from the request path instead.
+    */
+    if ($page === '') {
+        $uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?? '';
+        $base = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
+        if ($base !== '/' && $base !== '' && strpos($uri, $base) === 0) {
+            $uri = substr($uri, strlen($base));
+        }
+        $page = rawurldecode($uri);
+    }
+
     $page = trim($page, '/');
 
     /*


### PR DESCRIPTION
## Fix #42 

Add a server-agnostic fallback in `index.php`: when `$_GET['page']` is empty,
derive the route from the request path. This replicates what the Apache
rewrite does, but in PHP, so it works on nginx, Apache, **and** the PHP
built-in server. It is a no-op when Apache already populated `page`, and it
handles subdirectory installs via `SCRIPT_NAME`.

```php
$page = $_GET['page'] ?? '';

// Fallback router for servers without .htaccess rewriting (nginx, etc.)
if ($page === '') {
    $uri  = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?? '';
    $base = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'] ?? ''));
    if ($base !== '/' && $base !== '' && strpos($uri, $base) === 0) {
        $uri = substr($uri, strlen($base));
    }
    $page = rawurldecode($uri);
}

$page = trim($page, '/');
```

### After the fix

```bash
curl -sk https://SITE/login      # => ...<h2>Login to your account</h2>...
curl -sk https://SITE/forgot     # => forgot-password page
curl -sk https://SITE/           # => single redirect to /login, then the form renders
```

## Notes

- For nginx deployments, the `.htaccess` rule that blocks direct `*.php` access
  is not enforced, so `/index.php?page=...` is directly reachable. That is a
  separate hardening concern and not part of this fix.
- An alternative fix is to ship an nginx config snippet, but the PHP fallback
  is preferred because it works across all servers without per-host setup.
