### PR TITLE
Fix PHP opening tag placement in NowpaymentsGateway class

### DIFF
--- a/pp-content/pp-modules/pp-gateways/nowpayments/class.php
+++ b/pp-content/pp-modules/pp-gateways/nowpayments/class.php
@@ -1,3 +1,4 @@
+<?php
 /**
  * Piprapay NowPayments Module
  *
@@ -9,7 +10,6 @@
  * @link      https://github.com/obaidullahrion
  */
 
-<?php
     class NowpaymentsGateway
     {
         public function info()


### PR DESCRIPTION
## Fix #40 

  `pp-content/pp-modules/pp-gateways/nowpayments/class.php` opened with a docblock
  comment *before* the `<?php` tag. Everything before `<?php` is treated as plain                                                                                 
  output, so the docblock was emitted as raw text whenever the file was included.

  This causes stray text/"headers already sent" issues when the module is loaded —
  including during the admin **Gateways → New Gateway** dropdown scan, which
  `require_once`s every gateway's `class.php`.