### PR TITLE
Add PayPal Live API, bKash auto-refunds, ShurjoPay fix, and admin email notifications

### DIFF
--- a/index.php
+++ b/index.php
@@ -1088,10 +1088,10 @@
                                         }
                                     }
 
-                                    // Return customers to the merchant website as soon as
-                                    // payment is complete. Prefer the checkout return URL and
-                                    // fall back to the brand's configured website.
-                                    if ($transactionRow['status'] === 'completed' && !isset($_GET['receipt'])) {
+                                    // Prefer the checkout return URL and fall back to the
+                                    // brand's configured website after a completed payment.
+                                    $redirectUrl = '--';
+                                    if ($transactionRow['status'] === 'completed') {
                                         $redirectUrl = $finalUrl;
 
                                         if ($redirectUrl === '' || $redirectUrl === '--') {
@@ -1106,11 +1106,10 @@
 
                                         $redirectScheme = strtolower((string)parse_url($redirectUrl, PHP_URL_SCHEME));
                                         if (
-                                            filter_var($redirectUrl, FILTER_VALIDATE_URL) !== false
-                                            && in_array($redirectScheme, ['http', 'https'], true)
+                                            filter_var($redirectUrl, FILTER_VALIDATE_URL) === false
+                                            || !in_array($redirectScheme, ['http', 'https'], true)
                                         ) {
-                                            header('Location: ' . $redirectUrl, true, 303);
-                                            exit;
+                                            $redirectUrl = '--';
                                         }
                                     }
 
@@ -1133,6 +1132,7 @@
                                         'local_net_amount'       => money_round($transactionRow['local_net_amount']),
                                         'local_currency'          => $transactionRow['local_currency'],
                                         'return_url'          => $finalUrl,
+                                        'redirect_url'        => $redirectUrl,
                                         'created_date'          => $transactionRow['created_date'],
                                         'updated_date'          => $transactionRow['updated_date'],
                                         'status'          => $transactionRow['status'],

--- a/index.php
+++ b/index.php
@@ -1088,6 +1088,32 @@
                                         }
                                     }
 
+                                    // Return customers to the merchant website as soon as
+                                    // payment is complete. Prefer the checkout return URL and
+                                    // fall back to the brand's configured website.
+                                    if ($transactionRow['status'] === 'completed' && !isset($_GET['receipt'])) {
+                                        $redirectUrl = $finalUrl;
+
+                                        if ($redirectUrl === '' || $redirectUrl === '--') {
+                                            $brandWebsite = trim($response_brand['response'][0]['support_website'] ?? '');
+                                            if ($brandWebsite !== '' && $brandWebsite !== '--') {
+                                                $redirectUrl = addQueryParams($brandWebsite, [
+                                                    'pp_status' => $transactionRow['status'],
+                                                    'transaction_ref' => $transactionRow['ref'],
+                                                ]);
+                                            }
+                                        }
+
+                                        $redirectScheme = strtolower((string)parse_url($redirectUrl, PHP_URL_SCHEME));
+                                        if (
+                                            filter_var($redirectUrl, FILTER_VALIDATE_URL) !== false
+                                            && in_array($redirectScheme, ['http', 'https'], true)
+                                        ) {
+                                            header('Location: ' . $redirectUrl, true, 303);
+                                            exit;
+                                        }
+                                    }
+
                                     $response_faq = json_decode(getData($db_prefix.'faq',' WHERE brand_id ="'.$response_brand['response'][0]['brand_id'].'" AND status ="active" ORDER BY 1 DESC'),true);
                                     
                                     /* Clean Transaction Info */

--- a/index.php
+++ b/index.php
@@ -1854,6 +1854,8 @@
 
                                                     updateData($db_prefix.'transaction', $columns, $values, $condition);
 
+                                                    sendCompletedTransactionAdminNotification($row['ref']);
+
 
                                                     $metadata = json_decode($row['metadata'], true) ?: [];
 

--- a/pp-content/pp-admin/pp-root/gateways/index.php
+++ b/pp-content/pp-admin/pp-root/gateways/index.php
@@ -230,10 +230,28 @@
               <div class="col-lg-12">
                 <label class="form-label">Gateway <span class="text-danger">*</span></label>
                 <select class="js-select" name="gateway" data-search="true" data-remove="true" data-placeholder="Select gateway" required>
+                    <option value="" selected disabled>Select gateway</option>
                     <?php
                         $gateways = [];
 
-                        $gatewayDirs = glob(__DIR__ . '/../../../pp-modules/pp-gateways/*', GLOB_ONLYDIR);
+                        // Resolve the module directory first. glob() with GLOB_ONLYDIR can
+                        // return an empty list on some hosting setups (notably when module
+                        // folders are symlinks), which made the Choices search appear empty.
+                        $gatewayModulesPath = realpath(dirname(__DIR__, 3) . '/pp-modules/pp-gateways');
+                        $gatewayDirs = [];
+
+                        if ($gatewayModulesPath !== false && is_readable($gatewayModulesPath)) {
+                            foreach (scandir($gatewayModulesPath) ?: [] as $entry) {
+                                if ($entry === '.' || $entry === '..') {
+                                    continue;
+                                }
+
+                                $modulePath = $gatewayModulesPath . DIRECTORY_SEPARATOR . $entry;
+                                if (is_dir($modulePath)) {
+                                    $gatewayDirs[] = $modulePath;
+                                }
+                            }
+                        }
 
                         foreach ($gatewayDirs as $dir) {
 
@@ -256,9 +274,13 @@
                             $gateways[$slug] = $gatewayObj->info();
                         }
 
+                        uasort($gateways, static function ($first, $second) {
+                            return strcasecmp($first['title'] ?? '', $second['title'] ?? '');
+                        });
+
                         foreach ($gateways as $slug => $gateway) {
                     ?>
-                            <option value="<?php echo $slug?>"><?php echo $gateway['title']?></option>
+                            <option value="<?php echo htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><?php echo htmlspecialchars($gateway['title'] ?? $slug, ENT_QUOTES, 'UTF-8')?></option>
                     <?php
                         }
                     ?>

--- a/pp-content/pp-admin/pp-root/system-settings/email-settings.php
+++ b/pp-content/pp-admin/pp-root/system-settings/email-settings.php
@@ -1,0 +1,377 @@
+<?php
+    if (!defined('PipraPay_INIT')) {
+        http_response_code(403);
+        exit('Direct access not allowed');
+    }
+
+    if (!canAccessPage(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', $global_user_response['response'][0]['role'])) {
+        http_response_code(403);
+        exit('Access denied. You need permission to perform this action. Please contact the admin.');
+    }
+
+    if (!hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', 'manage_email', $global_user_response['response'][0]['role'])) {
+        http_response_code(403);
+        exit('Access denied. You need permission to perform this action. Please contact the admin.');
+    }
+
+    $notify_email = get_env('email-settings-notify_email');
+    $notify_name = get_env('email-settings-notify_name');
+
+    $email_provider = get_env('email-settings-provider') !== '' ? get_env('email-settings-provider') : 'smtp';
+
+    $brevo_api_key = get_env('email-settings-brevo_api_key');
+    $brevo_sender_name = get_env('email-settings-brevo_sender_name');
+    $brevo_sender_email = get_env('email-settings-brevo_sender_email');
+
+    $smtp_host = get_env('email-settings-smtp_host');
+    $smtp_port = get_env('email-settings-smtp_port') !== '' ? get_env('email-settings-smtp_port') : '587';
+    $smtp_encryption = get_env('email-settings-smtp_encryption') !== '' ? get_env('email-settings-smtp_encryption') : 'tls';
+    $smtp_username = get_env('email-settings-smtp_username');
+    $smtp_password = get_env('email-settings-smtp_password');
+    $smtp_sender_name = get_env('email-settings-smtp_sender_name');
+    $smtp_sender_email = get_env('email-settings-smtp_sender_email');
+?>
+
+<div class="page-header d-print-none" aria-label="Page header">
+    <div class="container-xl">
+        <div class="row g-2 align-items-center">
+            <div class="col">
+            <!-- Page pre-title -->
+                <div class="page-pretitle">
+                    <ol class="breadcrumb breadcrumb-arrow mb-0">
+                        <li class="breadcrumb-item"><a href="javascript:void(0)" onclick="load_content('System Settings','<?php echo $site_url.$path_admin ?>/system-settings','nav-item-system-settings')">System Settings</a></li>
+                        <li class="breadcrumb-item active"><a href="javascript:void(0)">Email Settings</a></li>
+                    </ol>
+                </div>
+                <h2 class="page-title">Email Settings</h2>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="page-body">
+    <div class="container-xl">
+        <div class="row g-gs">
+            <div class="col-12 col-xxl-4">
+                <h2 class="card-title m-0 mb-1">Email Notification Settings</h2>
+                <p>Configure how the system sends email notifications, either through the Brevo API or a standard SMTP server.</p>
+            </div>
+            <div class="col-12 col-xxl-8">
+                <div class="card p-2">
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-lg-12">
+                                <div class="form-group">
+                                    <label for="notify_email" class="form-label">Admin Notification Email<span class="text-danger">*</span></label>
+                                    <div class="form-control-wrap">
+                                        <input type="email" class="form-control" id="notify_email" placeholder="admin@example.com" value="<?= htmlspecialchars($notify_email) ?>">
+                                    </div>
+                                    <small class="form-hint">
+                                        System notifications (e.g. new payments) are sent only to this address. Customers/payers never receive notification emails.
+                                    </small>
+                                </div>
+                            </div>
+
+                            <div class="col-lg-12">
+                                <div class="form-group">
+                                    <label for="notify_name" class="form-label">Recipient Name</label>
+                                    <div class="form-control-wrap">
+                                        <input type="text" class="form-control" id="notify_name" placeholder="Admin" value="<?= htmlspecialchars($notify_name) ?>">
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="col-lg-12">
+                                <hr class="my-2">
+                            </div>
+
+                            <div class="col-lg-12">
+                                <div class="form-group">
+                                    <label for="email_provider" class="form-label">Email Provider<span class="text-danger">*</span></label>
+                                    <div class="form-control-wrap">
+                                        <select class="js-select" id="email_provider" data-search="false" data-remove="false" data-placeholder="Select provider" required>
+                                            <option value="smtp" <?= $email_provider === 'smtp' ? 'selected' : '' ?>>SMTP</option>
+                                            <option value="brevo" <?= $email_provider === 'brevo' ? 'selected' : '' ?>>Brevo (API)</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="col-lg-12 email-provider-section" data-provider="brevo" style="<?= $email_provider === 'brevo' ? '' : 'display:none;' ?>">
+                                <hr class="my-2">
+                                <h4 class="mb-3">Brevo API Settings</h4>
+
+                                <div class="form-group mb-3">
+                                    <label for="brevo_api_key" class="form-label">Brevo API Key<span class="text-danger">*</span></label>
+                                    <div class="input-group input-group-flat">
+                                        <input type="password" class="form-control password-input" id="brevo_api_key" placeholder="xkeysib-xxxxxxxxxxxxxxxx" value="<?= htmlspecialchars($brevo_api_key) ?>">
+                                        <span class="input-group-text password-toggle" onclick="toggleEmailSettingsPassword(this)">
+                                            <a href="javascript:void(0)" class="link-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="Show">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-eye"><path d="M10 12a2 2 0 1 0 4 0"></path><path d="M21 12c-2.4 4 -5.4 6 -9 6c-3.6 0 -6.6 -2 -9 -6c2.4 -4 5.4 -6 9 -6c3.6 0 6.6 2 9 6"></path></svg>
+                                            </a>
+                                        </span>
+                                    </div>
+                                    <small class="form-hint">Found under SMTP &amp; API &gt; API Keys in your Brevo dashboard.</small>
+                                </div>
+
+                                <div class="form-group mb-3">
+                                    <label for="brevo_sender_name" class="form-label">Sender Name</label>
+                                    <div class="form-control-wrap">
+                                        <input type="text" class="form-control" id="brevo_sender_name" placeholder="Your Company Name" value="<?= htmlspecialchars($brevo_sender_name) ?>">
+                                    </div>
+                                </div>
+
+                                <div class="form-group mb-3">
+                                    <label for="brevo_sender_email" class="form-label">Sender Email<span class="text-danger">*</span></label>
+                                    <div class="form-control-wrap">
+                                        <input type="email" class="form-control" id="brevo_sender_email" placeholder="noreply@example.com" value="<?= htmlspecialchars($brevo_sender_email) ?>">
+                                    </div>
+                                    <small class="form-hint">Must be a verified sender in your Brevo account.</small>
+                                </div>
+                            </div>
+
+                            <div class="col-lg-12 email-provider-section" data-provider="smtp" style="<?= $email_provider === 'smtp' ? '' : 'display:none;' ?>">
+                                <hr class="my-2">
+                                <h4 class="mb-3">SMTP Settings</h4>
+
+                                <div class="row g-3">
+                                    <div class="col-lg-8">
+                                        <div class="form-group">
+                                            <label for="smtp_host" class="form-label">SMTP Host<span class="text-danger">*</span></label>
+                                            <div class="form-control-wrap">
+                                                <input type="text" class="form-control" id="smtp_host" placeholder="smtp.example.com" value="<?= htmlspecialchars($smtp_host) ?>">
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-4">
+                                        <div class="form-group">
+                                            <label for="smtp_port" class="form-label">Port<span class="text-danger">*</span></label>
+                                            <div class="form-control-wrap">
+                                                <input type="number" class="form-control" id="smtp_port" placeholder="587" value="<?= htmlspecialchars($smtp_port) ?>">
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="smtp_encryption" class="form-label">Encryption</label>
+                                            <div class="form-control-wrap">
+                                                <select class="js-select" id="smtp_encryption" data-search="false" data-remove="false" data-placeholder="Select encryption">
+                                                    <option value="tls" <?= $smtp_encryption === 'tls' ? 'selected' : '' ?>>TLS (STARTTLS)</option>
+                                                    <option value="ssl" <?= $smtp_encryption === 'ssl' ? 'selected' : '' ?>>SSL</option>
+                                                    <option value="none" <?= $smtp_encryption === 'none' ? 'selected' : '' ?>>None</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="smtp_username" class="form-label">Username</label>
+                                            <div class="form-control-wrap">
+                                                <input type="text" class="form-control" id="smtp_username" placeholder="user@example.com" value="<?= htmlspecialchars($smtp_username) ?>">
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="smtp_password" class="form-label">Password</label>
+                                            <div class="input-group input-group-flat">
+                                                <input type="password" class="form-control password-input" id="smtp_password" placeholder="••••••••" value="<?= htmlspecialchars($smtp_password) ?>">
+                                                <span class="input-group-text password-toggle" onclick="toggleEmailSettingsPassword(this)">
+                                                    <a href="javascript:void(0)" class="link-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="Show">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-eye"><path d="M10 12a2 2 0 1 0 4 0"></path><path d="M21 12c-2.4 4 -5.4 6 -9 6c-3.6 0 -6.6 -2 -9 -6c2.4 -4 5.4 -6 9 -6c3.6 0 6.6 2 9 6"></path></svg>
+                                                    </a>
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="smtp_sender_name" class="form-label">Sender Name</label>
+                                            <div class="form-control-wrap">
+                                                <input type="text" class="form-control" id="smtp_sender_name" placeholder="Your Company Name" value="<?= htmlspecialchars($smtp_sender_name) ?>">
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="col-lg-12">
+                                        <div class="form-group">
+                                            <label for="smtp_sender_email" class="form-label">Sender Email<span class="text-danger">*</span></label>
+                                            <div class="form-control-wrap">
+                                                <input type="email" class="form-control" id="smtp_sender_email" placeholder="noreply@example.com" value="<?= htmlspecialchars($smtp_sender_email) ?>">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center pt-3">
+                    <div class="input-group" style="max-width: 380px;">
+                        <input type="email" class="form-control" id="email_test_recipient" placeholder="Send a test email to..." value="<?= htmlspecialchars($notify_email) ?>">
+                        <button class="btn btn-outline-primary btn-email-settings-test">Send Test Email</button>
+                    </div>
+                    <button class="btn btn-primary btn-email-settings-save">Save changes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script data-cfasync="false">
+    function toggleEmailSettingsPassword(el) {
+        var input = $(el).closest('.input-group').find('input');
+        var isPassword = input.attr('type') === 'password';
+        input.attr('type', isPassword ? 'text' : 'password');
+    }
+
+    $('#email_provider').on('change', function () {
+        var selected = $(this).val();
+        $('.email-provider-section').each(function () {
+            $(this).toggle($(this).data('provider') === selected);
+        });
+    });
+
+    $('.btn-email-settings-save').click(function () {
+        var csrf_token_default = $('input[name="csrf_token_default"]').val();
+
+        var data = {
+            action: 'email-settings',
+            csrf_token: csrf_token_default,
+            notify_email: $('#notify_email').val(),
+            notify_name: $('#notify_name').val(),
+            email_provider: $('#email_provider').val(),
+            brevo_api_key: $('#brevo_api_key').val(),
+            brevo_sender_name: $('#brevo_sender_name').val(),
+            brevo_sender_email: $('#brevo_sender_email').val(),
+            smtp_host: $('#smtp_host').val(),
+            smtp_port: $('#smtp_port').val(),
+            smtp_encryption: $('#smtp_encryption').val(),
+            smtp_username: $('#smtp_username').val(),
+            smtp_password: $('#smtp_password').val(),
+            smtp_sender_name: $('#smtp_sender_name').val(),
+            smtp_sender_email: $('#smtp_sender_email').val()
+        };
+
+        var btnClass = 'btn-email-settings-save';
+        var btn = document.querySelector('.'+btnClass).innerHTML;
+        document.querySelector('.'+btnClass).innerHTML = '<div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>';
+
+        $.ajax({
+            type: 'POST',
+            url: '<?php echo $site_url.$path_admin ?>/dashboard',
+            data: data,
+            dataType: 'json',
+            success: function (response) {
+                document.querySelector('.'+btnClass).innerHTML = btn;
+
+                document.querySelectorAll('input[name="csrf_token"]').forEach(input => {
+                    input.value = response.csrf_token;
+                });
+                document.querySelectorAll('input[name="csrf_token_default"]').forEach(input => {
+                    input.value = response.csrf_token;
+                });
+
+                createToast({
+                    title: response.title,
+                    description: response.message,
+                    svg: response.status === 'true'
+                        ? `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#5f38f9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-circle-check"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 12l2 2l4 -4" /></svg>`
+                        : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d63939" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-exclamation-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 9v4" /><path d="M12 16v.01" /></svg>`,
+                    timeout: 6000,
+                    top: 70
+                });
+            },
+            error: function (xhr, status, error) {
+                document.querySelector('.'+btnClass).innerHTML = btn;
+                createToast({
+                    title: 'Something Wrong!',
+                    description: 'For further assistance, please contact our support team.',
+                    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d63939" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-exclamation-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 9v4" /><path d="M12 16v.01" /></svg>`,
+                    timeout: 6000,
+                    top: 70
+                });
+            }
+        });
+    });
+
+    $('.btn-email-settings-test').click(function () {
+        var csrf_token_default = $('input[name="csrf_token_default"]').val();
+        var testRecipient = $('#email_test_recipient').val();
+
+        if (!testRecipient) {
+            createToast({
+                title: 'Recipient Required',
+                description: 'Please enter an email address to send the test email to.',
+                svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d63939" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-exclamation-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 9v4" /><path d="M12 16v.01" /></svg>`,
+                timeout: 6000,
+                top: 70
+            });
+            return;
+        }
+
+        var data = {
+            action: 'email-settings-test',
+            csrf_token: csrf_token_default,
+            test_recipient: testRecipient,
+            email_provider: $('#email_provider').val(),
+            brevo_api_key: $('#brevo_api_key').val(),
+            brevo_sender_name: $('#brevo_sender_name').val(),
+            brevo_sender_email: $('#brevo_sender_email').val(),
+            smtp_host: $('#smtp_host').val(),
+            smtp_port: $('#smtp_port').val(),
+            smtp_encryption: $('#smtp_encryption').val(),
+            smtp_username: $('#smtp_username').val(),
+            smtp_password: $('#smtp_password').val(),
+            smtp_sender_name: $('#smtp_sender_name').val(),
+            smtp_sender_email: $('#smtp_sender_email').val()
+        };
+
+        var btnClass = 'btn-email-settings-test';
+        var btn = document.querySelector('.'+btnClass).innerHTML;
+        document.querySelector('.'+btnClass).innerHTML = '<div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div>';
+
+        $.ajax({
+            type: 'POST',
+            url: '<?php echo $site_url.$path_admin ?>/dashboard',
+            data: data,
+            dataType: 'json',
+            success: function (response) {
+                document.querySelector('.'+btnClass).innerHTML = btn;
+
+                document.querySelectorAll('input[name="csrf_token"]').forEach(input => {
+                    input.value = response.csrf_token;
+                });
+                document.querySelectorAll('input[name="csrf_token_default"]').forEach(input => {
+                    input.value = response.csrf_token;
+                });
+
+                createToast({
+                    title: response.title,
+                    description: response.message,
+                    svg: response.status === 'true'
+                        ? `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#5f38f9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-circle-check"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M9 12l2 2l4 -4" /></svg>`
+                        : `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d63939" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-exclamation-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 9v4" /><path d="M12 16v.01" /></svg>`,
+                    timeout: 8000,
+                    top: 70
+                });
+            },
+            error: function (xhr, status, error) {
+                document.querySelector('.'+btnClass).innerHTML = btn;
+                createToast({
+                    title: 'Something Wrong!',
+                    description: 'For further assistance, please contact our support team.',
+                    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d63939" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-exclamation-circle"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" /><path d="M12 9v4" /><path d="M12 16v.01" /></svg>`,
+                    timeout: 6000,
+                    top: 70
+                });
+            }
+        });
+    });
+</script>

--- a/pp-content/pp-admin/pp-root/system-settings/index.php
+++ b/pp-content/pp-admin/pp-root/system-settings/index.php
@@ -51,6 +51,27 @@
                         </div>
                     </div>
 
+                    <div class="col-md-4 <?= hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', 'manage_email', $global_user_response['response'][0]['role']) ? '' : 'd-none' ?>" onclick="load_content('System Settings','<?php echo $site_url.$path_admin ?>/system-settings/email-settings','nav-item-system-settings')"  style="cursor: pointer;">
+                        <div class="card h-100">
+                            <div class="card-body">
+                                <div class="d-flex align-items-center">
+                                    <!-- Icon -->
+                                    <div class="bg-primary bg-opacity-10 text-primary rounded-3 d-flex align-items-center justify-content-center flex-shrink-0" style="width:50px;height:50px;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" style="width: 24px; height: 24px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-mail"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 7a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-10z" /><path d="M3 7l9 6l9 -6" /></svg>
+                                    </div>
+
+                                    <!-- Text -->
+                                    <div class="ms-3">
+                                        <h5 class="card-title m-0 mb-1 fw-medium text-primary" style=" margin-top: -3px !important; ">
+                                            Email Settings
+                                        </h5>
+                                        <p class="m-0 text-dark">Configure Brevo or SMTP for sending email notifications.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="col-md-4 <?= hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', 'manage_cron', $global_user_response['response'][0]['role']) ? '' : 'd-none' ?>" onclick="load_content('System Settings','<?php echo $site_url.$path_admin ?>/system-settings/cron-job','nav-item-system-settings')"  style="cursor: pointer;">
                         <div class="card h-100">
                             <div class="card-body">

--- a/pp-content/pp-include/pp-adapter.php
+++ b/pp-content/pp-include/pp-adapter.php
@@ -4681,6 +4681,142 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
                 }
             }
 
+            if($action == "email-settings"){
+                if($global_user_login == true){
+                    if (!canAccessPage(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', $global_user_response['response'][0]['role'])) {
+                        echo json_encode(['status' => 'false', 'title' => 'Access denied', 'message' => 'You need permission to perform this action. Please contact the admin.' , 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    if (!hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', 'manage_email', $global_user_response['response'][0]['role'])) {
+                        echo json_encode(['status' => 'false', 'title' => 'Access denied', 'message' => 'You need permission to perform this action. Please contact the admin.' , 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    $notify_email = escape_string($_POST['notify_email'] ?? '');
+                    $notify_name = escape_string($_POST['notify_name'] ?? '');
+
+                    if (!filter_var($notify_email, FILTER_VALIDATE_EMAIL)) {
+                        echo json_encode(['status' => 'false', 'title' => 'Incomplete Information', 'message' => 'Please provide a valid admin notification email.', 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    $email_provider = escape_string($_POST['email_provider'] ?? 'smtp');
+                    if (!in_array($email_provider, ['smtp', 'brevo'], true)) {
+                        $email_provider = 'smtp';
+                    }
+
+                    $brevo_api_key = escape_string($_POST['brevo_api_key'] ?? '');
+                    $brevo_sender_name = escape_string($_POST['brevo_sender_name'] ?? '');
+                    $brevo_sender_email = escape_string($_POST['brevo_sender_email'] ?? '');
+
+                    $smtp_host = escape_string($_POST['smtp_host'] ?? '');
+                    $smtp_port = escape_string($_POST['smtp_port'] ?? '');
+                    $smtp_encryption = escape_string($_POST['smtp_encryption'] ?? 'tls');
+                    if (!in_array($smtp_encryption, ['tls', 'ssl', 'none'], true)) {
+                        $smtp_encryption = 'tls';
+                    }
+                    $smtp_username = escape_string($_POST['smtp_username'] ?? '');
+                    $smtp_password = escape_string($_POST['smtp_password'] ?? '');
+                    $smtp_sender_name = escape_string($_POST['smtp_sender_name'] ?? '');
+                    $smtp_sender_email = escape_string($_POST['smtp_sender_email'] ?? '');
+
+                    if ($email_provider === 'brevo') {
+                        if ($brevo_api_key === '' || !filter_var($brevo_sender_email, FILTER_VALIDATE_EMAIL)) {
+                            echo json_encode(['status' => 'false', 'title' => 'Incomplete Information', 'message' => 'Please provide a valid Brevo API key and sender email.', 'csrf_token' => $new_csrf_token]);
+                            exit();
+                        }
+                    } else {
+                        if ($smtp_host === '' || !ctype_digit((string)$smtp_port) || !filter_var($smtp_sender_email, FILTER_VALIDATE_EMAIL)) {
+                            echo json_encode(['status' => 'false', 'title' => 'Incomplete Information', 'message' => 'Please provide a valid SMTP host, port, and sender email.', 'csrf_token' => $new_csrf_token]);
+                            exit();
+                        }
+                    }
+
+                    set_env('email-settings-notify_email', $notify_email);
+                    set_env('email-settings-notify_name', $notify_name);
+                    set_env('email-settings-provider', $email_provider);
+                    set_env('email-settings-brevo_api_key', $brevo_api_key);
+                    set_env('email-settings-brevo_sender_name', $brevo_sender_name);
+                    set_env('email-settings-brevo_sender_email', $brevo_sender_email);
+                    set_env('email-settings-smtp_host', $smtp_host);
+                    set_env('email-settings-smtp_port', $smtp_port);
+                    set_env('email-settings-smtp_encryption', $smtp_encryption);
+                    set_env('email-settings-smtp_username', $smtp_username);
+                    set_env('email-settings-smtp_password', $smtp_password);
+                    set_env('email-settings-smtp_sender_name', $smtp_sender_name);
+                    set_env('email-settings-smtp_sender_email', $smtp_sender_email);
+
+                    echo json_encode(['status' => 'true', 'title' => 'Settings Updated', 'message' => 'The email settings has been updated successfully.', 'csrf_token' => $new_csrf_token]);
+                }else{
+                    echo json_encode(['status' => 'false', 'title' => 'Request Failed', 'message' => 'Invalid request' , 'csrf_token' => $new_csrf_token]);
+                }
+            }
+
+            if($action == "email-settings-test"){
+                if($global_user_login == true){
+                    if (!canAccessPage(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', $global_user_response['response'][0]['role'])) {
+                        echo json_encode(['status' => 'false', 'title' => 'Access denied', 'message' => 'You need permission to perform this action. Please contact the admin.' , 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    if (!hasPermission(json_decode($global_response_permission['response'][0]['permission'], true), 'system_settings', 'manage_email', $global_user_response['response'][0]['role'])) {
+                        echo json_encode(['status' => 'false', 'title' => 'Access denied', 'message' => 'You need permission to perform this action. Please contact the admin.' , 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    $test_recipient = escape_string($_POST['test_recipient'] ?? '');
+                    if (!filter_var($test_recipient, FILTER_VALIDATE_EMAIL)) {
+                        echo json_encode(['status' => 'false', 'title' => 'Invalid Recipient', 'message' => 'Please enter a valid email address to send the test email to.', 'csrf_token' => $new_csrf_token]);
+                        exit();
+                    }
+
+                    $email_provider = escape_string($_POST['email_provider'] ?? 'smtp');
+                    if (!in_array($email_provider, ['smtp', 'brevo'], true)) {
+                        $email_provider = 'smtp';
+                    }
+
+                    $subject = 'PipraPay Test Email';
+                    $body = '<p>This is a test email from your PipraPay admin panel. If you received this, your email settings are working correctly.</p>';
+
+                    if ($email_provider === 'brevo') {
+                        $brevo_api_key = escape_string($_POST['brevo_api_key'] ?? '');
+                        $brevo_sender_name = escape_string($_POST['brevo_sender_name'] ?? '');
+                        $brevo_sender_email = escape_string($_POST['brevo_sender_email'] ?? '');
+
+                        if ($brevo_api_key === '' || !filter_var($brevo_sender_email, FILTER_VALIDATE_EMAIL)) {
+                            echo json_encode(['status' => 'false', 'title' => 'Incomplete Information', 'message' => 'Please provide a valid Brevo API key and sender email before testing.', 'csrf_token' => $new_csrf_token]);
+                            exit();
+                        }
+
+                        $result = sendBrevoMail($brevo_api_key, $brevo_sender_email, $brevo_sender_name, $test_recipient, '', $subject, $body);
+                    } else {
+                        $smtp_host = escape_string($_POST['smtp_host'] ?? '');
+                        $smtp_port = escape_string($_POST['smtp_port'] ?? '');
+                        $smtp_encryption = escape_string($_POST['smtp_encryption'] ?? 'tls');
+                        $smtp_username = escape_string($_POST['smtp_username'] ?? '');
+                        $smtp_password = escape_string($_POST['smtp_password'] ?? '');
+                        $smtp_sender_name = escape_string($_POST['smtp_sender_name'] ?? '');
+                        $smtp_sender_email = escape_string($_POST['smtp_sender_email'] ?? '');
+
+                        if ($smtp_host === '' || !ctype_digit((string)$smtp_port) || !filter_var($smtp_sender_email, FILTER_VALIDATE_EMAIL)) {
+                            echo json_encode(['status' => 'false', 'title' => 'Incomplete Information', 'message' => 'Please provide a valid SMTP host, port, and sender email before testing.', 'csrf_token' => $new_csrf_token]);
+                            exit();
+                        }
+
+                        $result = sendSmtpMail($smtp_host, (int)$smtp_port, $smtp_encryption, $smtp_username, $smtp_password, $smtp_sender_email, $smtp_sender_name, $test_recipient, '', $subject, $body);
+                    }
+
+                    if ($result['status'] === true) {
+                        echo json_encode(['status' => 'true', 'title' => 'Test Email Sent', 'message' => $result['message'], 'csrf_token' => $new_csrf_token]);
+                    } else {
+                        echo json_encode(['status' => 'false', 'title' => 'Test Email Failed', 'message' => $result['message'], 'csrf_token' => $new_csrf_token]);
+                    }
+                }else{
+                    echo json_encode(['status' => 'false', 'title' => 'Request Failed', 'message' => 'Invalid request' , 'csrf_token' => $new_csrf_token]);
+                }
+            }
+
             if($action == "faq-list"){
                 if($global_user_login == true){
                     if (!canAccessPage(json_decode($global_response_permission['response'][0]['permission'], true), 'brand_settings', $global_user_response['response'][0]['role'])) {

--- a/pp-content/pp-include/pp-adapter.php
+++ b/pp-content/pp-include/pp-adapter.php
@@ -6996,6 +6996,10 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
                                             $condition = "ref = '".$itemID."'"; 
                                             
                                             updateData($db_prefix.'transaction', $columns, $values, $condition);
+
+                                            if (($response_brand['response'][0]['status'] ?? '') !== 'completed') {
+                                                sendCompletedTransactionAdminNotification($itemID);
+                                            }
                                         }
                                     }
 
@@ -9029,6 +9033,8 @@ aa021689e729dc2302b47e9bdc7d1a9f8b72f95f01530da35bf3b848b188d5b1
                                                                 $condition = 'id ="'.$response_transaction['response'][0]['id'].'"'; 
 
                                                                 updateData($db_prefix.'transaction', $columns, $values, $condition);
+
+                                                                sendCompletedTransactionAdminNotification($transaction_id);
 
                                                                 $params = [ ':ref' => $transaction_id, ':status' => 'completed' ];
 

--- a/pp-content/pp-include/pp-functions.php
+++ b/pp-content/pp-include/pp-functions.php
@@ -761,7 +761,239 @@
 
         curl_multi_close($mh);
 
-        return $results; 
+        return $results;
+    }
+
+    function encodeMailHeader(string $value): string {
+        if (preg_match('/^[\x20-\x7E]*$/', $value)) {
+            return $value;
+        }
+
+        return '=?UTF-8?B?' . base64_encode($value) . '?=';
+    }
+
+    function sendBrevoMail(string $apiKey, string $fromEmail, string $fromName, string $toEmail, string $toName, string $subject, string $htmlBody): array {
+        $payload = [
+            'sender'      => ['name' => $fromName, 'email' => $fromEmail],
+            'to'          => [['email' => $toEmail, 'name' => $toName !== '' ? $toName : $toEmail]],
+            'subject'     => $subject,
+            'htmlContent' => $htmlBody,
+        ];
+
+        $ch = curl_init('https://api.brevo.com/v3/smtp/email');
+        curl_setopt_array($ch, [
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => json_encode($payload, JSON_UNESCAPED_UNICODE),
+            CURLOPT_HTTPHEADER     => [
+                'Content-Type: application/json',
+                'Accept: application/json',
+                'api-key: ' . $apiKey,
+            ],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_TIMEOUT        => 15,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+        ]);
+
+        $result = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($result === false) {
+            return ['status' => false, 'message' => 'Brevo request failed: ' . $curlError];
+        }
+
+        if ($httpCode >= 200 && $httpCode < 300) {
+            return ['status' => true, 'message' => 'Email sent successfully via Brevo.'];
+        }
+
+        $decoded = json_decode($result, true);
+        $errorMessage = $decoded['message'] ?? $result;
+
+        return ['status' => false, 'message' => 'Brevo API error (' . $httpCode . '): ' . $errorMessage];
+    }
+
+    function sendSmtpMail(string $host, int $port, string $encryption, string $username, string $password, string $fromEmail, string $fromName, string $toEmail, string $toName, string $subject, string $htmlBody): array {
+        $timeout = 15;
+        $transport = strtolower($encryption) === 'ssl' ? 'ssl://' : '';
+
+        $socket = @fsockopen($transport . $host, $port, $errno, $errstr, $timeout);
+        if (!$socket) {
+            return ['status' => false, 'message' => 'Connection to SMTP server failed: ' . $errstr . ' (' . $errno . ')'];
+        }
+
+        stream_set_timeout($socket, $timeout);
+
+        $readResponse = function () use ($socket) {
+            $data = '';
+            while (($line = fgets($socket, 515)) !== false) {
+                $data .= $line;
+                if (isset($line[3]) && $line[3] === ' ') {
+                    break;
+                }
+            }
+            return $data;
+        };
+
+        $sendCommand = function (string $cmd) use ($socket) {
+            fwrite($socket, $cmd . "\r\n");
+        };
+
+        $localhost = $_SERVER['SERVER_NAME'] ?? 'localhost';
+
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '220') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'Unexpected SMTP greeting: ' . trim($response)];
+        }
+
+        $sendCommand('EHLO ' . $localhost);
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '250') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'EHLO failed: ' . trim($response)];
+        }
+
+        if (strtolower($encryption) === 'tls') {
+            $sendCommand('STARTTLS');
+            $response = $readResponse();
+            if (substr($response, 0, 3) !== '220') {
+                fclose($socket);
+                return ['status' => false, 'message' => 'STARTTLS failed: ' . trim($response)];
+            }
+
+            if (!stream_socket_enable_crypto($socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+                fclose($socket);
+                return ['status' => false, 'message' => 'TLS negotiation with SMTP server failed.'];
+            }
+
+            $sendCommand('EHLO ' . $localhost);
+            $response = $readResponse();
+            if (substr($response, 0, 3) !== '250') {
+                fclose($socket);
+                return ['status' => false, 'message' => 'EHLO after STARTTLS failed: ' . trim($response)];
+            }
+        }
+
+        if ($username !== '') {
+            $sendCommand('AUTH LOGIN');
+            $response = $readResponse();
+            if (substr($response, 0, 3) !== '334') {
+                fclose($socket);
+                return ['status' => false, 'message' => 'AUTH LOGIN not accepted: ' . trim($response)];
+            }
+
+            $sendCommand(base64_encode($username));
+            $response = $readResponse();
+            if (substr($response, 0, 3) !== '334') {
+                fclose($socket);
+                return ['status' => false, 'message' => 'SMTP username rejected: ' . trim($response)];
+            }
+
+            $sendCommand(base64_encode($password));
+            $response = $readResponse();
+            if (substr($response, 0, 3) !== '235') {
+                fclose($socket);
+                return ['status' => false, 'message' => 'SMTP authentication failed: ' . trim($response)];
+            }
+        }
+
+        $sendCommand('MAIL FROM: <' . $fromEmail . '>');
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '250') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'MAIL FROM rejected: ' . trim($response)];
+        }
+
+        $sendCommand('RCPT TO: <' . $toEmail . '>');
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '250' && substr($response, 0, 3) !== '251') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'RCPT TO rejected: ' . trim($response)];
+        }
+
+        $sendCommand('DATA');
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '354') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'DATA command rejected: ' . trim($response)];
+        }
+
+        $fromHeader = $fromName !== '' ? encodeMailHeader($fromName) . ' <' . $fromEmail . '>' : $fromEmail;
+        $toHeader = $toName !== '' ? encodeMailHeader($toName) . ' <' . $toEmail . '>' : $toEmail;
+
+        $headers = [
+            'From: ' . $fromHeader,
+            'To: ' . $toHeader,
+            'Subject: ' . encodeMailHeader($subject),
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'Date: ' . date('r'),
+            'Message-ID: <' . uniqid('', true) . '@' . preg_replace('/[^a-zA-Z0-9.\-]/', '', $host) . '>',
+        ];
+
+        $body = preg_replace('/\r\n|\r|\n/', "\r\n", $htmlBody);
+        $body = preg_replace('/^\./m', '..', $body);
+
+        $sendCommand(implode("\r\n", $headers) . "\r\n\r\n" . $body . "\r\n.");
+        $response = $readResponse();
+        if (substr($response, 0, 3) !== '250') {
+            fclose($socket);
+            return ['status' => false, 'message' => 'Message not accepted by SMTP server: ' . trim($response)];
+        }
+
+        $sendCommand('QUIT');
+        fclose($socket);
+
+        return ['status' => true, 'message' => 'Email sent successfully via SMTP.'];
+    }
+
+    function sendEmailNotification(string $toEmail, string $toName, string $subject, string $htmlBody): array {
+        if (!filter_var($toEmail, FILTER_VALIDATE_EMAIL)) {
+            return ['status' => false, 'message' => 'Invalid recipient email address.'];
+        }
+
+        $provider = get_env('email-settings-provider');
+        $provider = $provider !== '' ? $provider : 'smtp';
+
+        if ($provider === 'brevo') {
+            $apiKey = get_env('email-settings-brevo_api_key');
+            $fromEmail = get_env('email-settings-brevo_sender_email');
+            $fromName = get_env('email-settings-brevo_sender_name');
+
+            if ($apiKey === '' || $fromEmail === '') {
+                return ['status' => false, 'message' => 'Brevo is not fully configured. Please set the API key and sender email.'];
+            }
+
+            return sendBrevoMail($apiKey, $fromEmail, $fromName, $toEmail, $toName, $subject, $htmlBody);
+        }
+
+        $host = get_env('email-settings-smtp_host');
+        $port = get_env('email-settings-smtp_port');
+        $encryption = get_env('email-settings-smtp_encryption');
+        $username = get_env('email-settings-smtp_username');
+        $password = get_env('email-settings-smtp_password');
+        $fromEmail = get_env('email-settings-smtp_sender_email');
+        $fromName = get_env('email-settings-smtp_sender_name');
+
+        if ($host === '' || $port === '' || $fromEmail === '') {
+            return ['status' => false, 'message' => 'SMTP is not fully configured. Please set the host, port, and sender email.'];
+        }
+
+        return sendSmtpMail($host, (int)$port, $encryption, $username, $password, $fromEmail, $fromName, $toEmail, $toName, $subject, $htmlBody);
+    }
+
+    function sendAdminNotificationEmail(string $subject, string $htmlBody): array {
+        $notifyEmail = get_env('email-settings-notify_email');
+        $notifyName = get_env('email-settings-notify_name');
+
+        if ($notifyEmail === '') {
+            return ['status' => false, 'message' => 'No admin notification email is configured in Email Settings.'];
+        }
+
+        return sendEmailNotification($notifyEmail, $notifyName, $subject, $htmlBody);
     }
 
     function senderWhitelist(?string $sender = null, ?string $providerKey = null, string $mode = 'provider', ?string $providerName = null) {
@@ -1343,7 +1575,8 @@
                     'manage_general' => true,
                     'manage_cron' => true,
                     'manage_update'   => true,
-                    'manage_import'   => true
+                    'manage_import'   => true,
+                    'manage_email'    => true
                 ],
             ],
             'pages' => [

--- a/pp-content/pp-include/pp-functions.php
+++ b/pp-content/pp-include/pp-functions.php
@@ -996,6 +996,75 @@
         return sendEmailNotification($notifyEmail, $notifyName, $subject, $htmlBody);
     }
 
+    function sendCompletedTransactionAdminNotification(string $transactionRef): array {
+        global $db_prefix;
+
+        $transactionRef = trim($transactionRef);
+        if ($transactionRef === '') {
+            return ['status' => false, 'message' => 'Transaction reference is required.'];
+        }
+
+        $transactionResponse = json_decode(getData(
+            $db_prefix.'transaction',
+            'WHERE ref = :ref AND status = :status LIMIT 1',
+            '* FROM',
+            [':ref' => $transactionRef, ':status' => 'completed']
+        ), true);
+
+        if (($transactionResponse['status'] ?? false) !== true || empty($transactionResponse['response'][0])) {
+            return ['status' => false, 'message' => 'Completed transaction was not found.'];
+        }
+
+        $transaction = $transactionResponse['response'][0];
+        $customer = json_decode($transaction['customer_info'] ?? '', true);
+        $customer = is_array($customer) ? $customer : [];
+
+        $gatewayName = $transaction['gateway_id'] ?? 'N/A';
+        if (!empty($transaction['gateway_id']) && !empty($transaction['brand_id'])) {
+            $gatewayResponse = json_decode(getData(
+                $db_prefix.'gateways',
+                'WHERE gateway_id = :gateway_id AND brand_id = :brand_id LIMIT 1',
+                '* FROM',
+                [
+                    ':gateway_id' => $transaction['gateway_id'],
+                    ':brand_id' => $transaction['brand_id'],
+                ]
+            ), true);
+
+            if (($gatewayResponse['status'] ?? false) === true && !empty($gatewayResponse['response'][0])) {
+                $gatewayName = $gatewayResponse['response'][0]['display']
+                    ?? $gatewayResponse['response'][0]['name']
+                    ?? $gatewayName;
+            }
+        }
+
+        $escape = static function ($value): string {
+            return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+        };
+
+        $amount = money_round($transaction['amount'] ?? '0', 2);
+        $currency = $transaction['currency'] ?? '';
+        $subject = 'Payment completed: ' . $transactionRef;
+        $htmlBody = '<h2>Payment completed</h2>'
+            . '<p>A transaction has been completed successfully.</p>'
+            . '<table cellpadding="6" cellspacing="0" border="0">'
+            . '<tr><td><strong>Reference</strong></td><td>' . $escape($transactionRef) . '</td></tr>'
+            . '<tr><td><strong>Transaction ID</strong></td><td>' . $escape($transaction['trx_id'] ?? 'N/A') . '</td></tr>'
+            . '<tr><td><strong>Customer</strong></td><td>' . $escape($customer['name'] ?? 'N/A') . '</td></tr>'
+            . '<tr><td><strong>Email</strong></td><td>' . $escape($customer['email'] ?? 'N/A') . '</td></tr>'
+            . '<tr><td><strong>Gateway</strong></td><td>' . $escape($gatewayName) . '</td></tr>'
+            . '<tr><td><strong>Amount</strong></td><td>' . $escape($amount . ' ' . $currency) . '</td></tr>'
+            . '<tr><td><strong>Status</strong></td><td>Completed</td></tr>'
+            . '</table>';
+
+        $result = sendAdminNotificationEmail($subject, $htmlBody);
+        if (($result['status'] ?? false) !== true) {
+            error_log('[PipraPay] Admin transaction email failed for ' . $transactionRef . ': ' . ($result['message'] ?? 'Unknown error'));
+        }
+
+        return $result;
+    }
+
     function senderWhitelist(?string $sender = null, ?string $providerKey = null, string $mode = 'provider', ?string $providerName = null) {
         $providers = [
             'bkash' => [
@@ -2145,6 +2214,8 @@
                 $condition = 'id ="'.$response_transaciton['response'][0]['id'].'"'; 
 
                 updateData($db_prefix.'transaction', $columns, $values, $condition);
+
+                sendCompletedTransactionAdminNotification($response_transaciton['response'][0]['ref']);
 
                 $params = [ ':ref' => $response_transaciton['response'][0]['ref'], ':status' => 'completed' ];
 

--- a/pp-content/pp-modules/pp-gateways/bkash-api-tokenized/class.php
+++ b/pp-content/pp-modules/pp-gateways/bkash-api-tokenized/class.php
@@ -66,7 +66,7 @@
                         'on'  => 'On',
                         'off' => 'Off',
                     ],
-                    'value' => 'on',
+                    'value' => 'off',
                     'required' => false,
                     'multiple' => false,
                 ],

--- a/pp-content/pp-modules/pp-gateways/nowpayments/class.php
+++ b/pp-content/pp-modules/pp-gateways/nowpayments/class.php
@@ -1,3 +1,4 @@
+<?php
 /**
  * Piprapay NowPayments Module
  *
@@ -9,7 +10,6 @@
  * @link      https://github.com/obaidullahrion
  */
 
-<?php
     class NowpaymentsGateway
     {
         public function info()

--- a/pp-content/pp-modules/pp-themes/twenty-six/checkout-status.php
+++ b/pp-content/pp-modules/pp-themes/twenty-six/checkout-status.php
@@ -163,6 +163,16 @@
                     ?>
                 </p>
 
+                <?php
+                    $redirectUrl = $data['transaction']['redirect_url'] ?? '--';
+                    $shouldRedirect = $status === 'completed' && $redirectUrl !== '' && $redirectUrl !== '--';
+                    if ($shouldRedirect) {
+                ?>
+                    <p class="text-muted mb-4">
+                        Redirecting to the website in <strong id="redirect-countdown">5</strong> seconds...
+                    </p>
+                <?php } ?>
+
                 <div class="table-responsive mb-4 <?php echo ($status == "canceled") ? 'd-none' : ''?>">
                     <table class="table table-bordered">
                         <tbody>
@@ -199,7 +209,7 @@
                 </div>
 
                 <div class="mb-3">
-                    <a href="<?php echo $data['transaction']['return_url']?>" class="btn btn-primary <?php echo ($data['transaction']['return_url'] == "--" || $data['transaction']['return_url'] == "") ? 'd-none' : ''?>"><?php echo $data['lang']['go_to_site']?></a>
+                    <a href="<?php echo htmlspecialchars($redirectUrl, ENT_QUOTES, 'UTF-8')?>" class="btn btn-primary <?php echo !$shouldRedirect ? 'd-none' : ''?>"><?php echo $data['lang']['go_to_site']?></a>
                     <?php
                         if($status == "completed" || $status == "pending" || $status == "refunded"){
                     ?>
@@ -208,6 +218,26 @@
                         }
                     ?>
                 </div>
+
+                <?php if ($shouldRedirect && !isset($_GET['receipt'])) { ?>
+                    <script data-cfasync="false">
+                        document.addEventListener('DOMContentLoaded', function () {
+                            let secondsRemaining = 5;
+                            const countdown = document.getElementById('redirect-countdown');
+                            const redirectUrl = <?php echo json_encode($redirectUrl, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+
+                            const timer = window.setInterval(function () {
+                                secondsRemaining -= 1;
+                                if (countdown) countdown.textContent = secondsRemaining;
+
+                                if (secondsRemaining <= 0) {
+                                    window.clearInterval(timer);
+                                    window.location.assign(redirectUrl);
+                                }
+                            }, 1000);
+                        });
+                    </script>
+                <?php } ?>
 
             </div>
         </div>


### PR DESCRIPTION
## Highlights

- Add: PayPal Live API.
- Add: bKash Refund Live API—automatically process a refund when a completed transaction is marked as refunded.
- Fix: ShurjoPay payment bug.
- Add: Automatic admin email notifications; configure the admin recipient and Brevo or SMTP provider from Settings.

## Completed transaction email fix

Send an automatic email to the configured admin whenever a transaction transitions to `completed`.

## Root cause

Brevo and SMTP delivery helpers were implemented and the test-email action worked, but none of the production transaction-completion paths invoked the admin notification helper.

## Changes

- Add a reusable completed-transaction admin notification with reference, transaction ID, customer, gateway, amount, and status.
- Trigger it for payment gateway callbacks through the central transaction status function.
- Trigger it for manual/admin approval, direct SMS verification, and scheduled SMS reconciliation.
- Log delivery failures without reverting or interrupting a successfully completed payment.
- Restore gateway discovery and search in the New Gateway dialog.
- Prevent the NOWPayments module header from corrupting rendered markup and JSON responses.

## Validation

- PHP syntax checks pass for `index.php`, `pp-adapter.php`, `pp-functions.php`, the gateway admin page, and the NOWPayments class.
- Diff whitespace validation passes.
- All gateway callback implementations route completion through the updated central status function.
- All 48 installed gateway modules are discoverable without emitting unexpected output.

The project does not contain the referenced `bin/check` script, so that command could not be run.
