### PR TITLE
Fix blank checkout page for bank gateways

### DIFF
--- a/pp-content/pp-include/pp-functions.php
+++ b/pp-content/pp-include/pp-functions.php
@@ -2663,7 +2663,7 @@
                             'copy' => true,
                             'value' => $data['transaction']['local_net_amount'],
                             'vars' => [
-                                '{amount}' => number_format($data['transaction']['local_net_amount'], 2),
+                                '{amount}' => number_format((float)$data['transaction']['local_net_amount'], 2),
                                 '{currency}' => $data['transaction']['local_currency']
                             ]
                         ],


### PR DESCRIPTION
## Problem

Any gateway created through **Gateways → Bank** renders a blank checkout page. The payer gets an HTTP 200 response that is truncated right after the gateway logo — no bank account details, no slip upload form, no error message, nothing actionable.

The `?gateway=<id>` page for a bank gateway returns roughly 7.5 KB of HTML with no closing `</body>`, while the same checkout's MFS gateway returns a complete ~18 KB page.

## Cause

`pp-content/pp-include/pp-functions.php` declares `strict_types=1` on line 2.

In `pp_gateway_render()`, the branch that handles gateways with no module of their own — which is every bank gateway — builds its instruction list with:

```php
'{amount}' => number_format($data['transaction']['local_net_amount'], 2),
```

`$data['transaction']['local_net_amount']` is assigned ~50 lines earlier from `money_round()`, whose return type is declared `: string`:

```php
$data['transaction']['local_net_amount'] = money_round($convertedAmount, 2);
```

```php
function money_round($amount, int $decimals = 2): string {
```

Under `strict_types=1` a numeric string is not accepted for `number_format()`'s `float` parameter, so the call raises an uncaught `TypeError` while the instruction array is still being constructed — before any of it is echoed. `pp-adapter.php` sets `display_errors` to `0`, so the failure is invisible to the payer and the page just stops.

Two things worth noting:

- **It is unconditional.** It does not depend on the amount, the currency, the conversion rate or the gateway configuration. Bank checkout is broken on every install that offers one.
- **Only bank gateways are affected.** Card and MFS gateways build their instructions in `pp-content/pp-modules/pp-gateways/<slug>/class.php`, none of which declare `strict_types`, so the same string-to-float pass is coerced silently there.

## Fix

Cast to `float` at the call site. This matches the cast already present on the commented-out `number_format()` call about 75 lines further down the same function:

```php
//$data['transaction']['discount_amount'] = number_format((float)$data['transaction']['discount_amount'],2,'.','');
```

One line changed. With the cast applied, the bank checkout renders its full instruction list (bank name, account name, account number, branch, routing number, SWIFT, amount) along with the slip upload form.

I also checked the slip submission path — the `transaction-verify` handler in `pp-adapter.php` — for the same class of problem. It contains no `number_format()` calls at all, so this single change is enough to make bank checkout work end to end.
